### PR TITLE
Fix typo 'subscribe'

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -9,7 +9,7 @@ lua-mirai基于事件驱动机制构建，lua-mirai中的事件包括好友、�
 示例：
 
 ``` lua
-bot:subsribeFriendMsg(
+bot:subscribeFriendMsg(
     function (bot, msg, sender)
     end
 )

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -35,7 +35,7 @@ local bot = Bot(qq账号,"qq密码","C:\\device.json")
 bot.login() --登录
 
 --在这里对bot进行事件订阅操作
---如 bot.subsribeXXX()
+--如 bot.subscribeXXX()
 
 bot.join() --挂起，防止进程结束
 

--- a/src/main/kotlin/com/ooooonly/luaMirai/lua/MiraiBot.kt
+++ b/src/main/kotlin/com/ooooonly/luaMirai/lua/MiraiBot.kt
@@ -318,5 +318,5 @@ class MiraiBot : LuaBot {
         }
     }
 
-    fun unSubsribeAll() = listeners[scriptId]?.forEach { it.value.complete() }
+    fun unSubscribeAll() = listeners[scriptId]?.forEach { it.value.complete() }
 }

--- a/src/main/kotlin/com/ooooonly/luaMirai/lua/MiraiGlobals.kt
+++ b/src/main/kotlin/com/ooooonly/luaMirai/lua/MiraiGlobals.kt
@@ -91,5 +91,5 @@ open class MiraiGlobals() : Globals() {
 
     fun onLoad() = onLoadFun?.call()
     fun onFinish() = onFinishFun?.call()
-    fun unSubsribeAll() = mBot?.unSubsribeAll()
+    fun unSubscribeAll() = mBot?.unSubscribeAll()
 }


### PR DESCRIPTION
This PR fixes all typos of 'subscribe', including typos in Kotlin code.