### PR TITLE
增加基于Zip包形式的脚本包加载支持

### DIFF
--- a/lua-mirai-adapter-luakt/build.gradle
+++ b/lua-mirai-adapter-luakt/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     implementation "org.xerial:sqlite-jdbc:3.7.2"
     implementation "org.jsoup:jsoup:1.7.3"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.2"
-    implementation "com.github.only52607.luakt:luakt:2.5.6"
+    implementation "com.github.only52607.luakt:luakt:2.5.7"
 }

--- a/lua-mirai-adapter-luakt/src/main/kotlin/com/github/only52607/luamirai/lua/LuaMiraiScript.kt
+++ b/lua-mirai-adapter-luakt/src/main/kotlin/com/github/only52607/luamirai/lua/LuaMiraiScript.kt
@@ -80,7 +80,11 @@ class LuaMiraiScript(
         if (coroutineContext[ContinuationInterceptor] == null) {
             coroutineContext += taskLib.asCoroutineDispatcher()
         }
-        mainFunc.invoke()
+        try {
+            mainFunc.invoke()
+        } catch (e: Exception) {
+            e.printStackTrace(PrintStream(stderr ?: System.err))
+        }
     }
 
     override suspend fun onStop() {
@@ -127,7 +131,7 @@ class LuaMiraiScript(
         private val parentFinder: ResourceFinder,
         private val botScriptResourceFinder: BotScriptResourceFinder?
     ) : ResourceFinder {
-        override fun findResource(filename: String): InputStream {
+        override fun findResource(filename: String): InputStream? {
             val resource = botScriptResourceFinder?.findResource(filename)
             if (resource != null) return resource
             return parentFinder.findResource(filename)

--- a/lua-mirai-adapter-luakt/src/main/kotlin/com/github/only52607/luamirai/lua/LuaMiraiScript.kt
+++ b/lua-mirai-adapter-luakt/src/main/kotlin/com/github/only52607/luamirai/lua/LuaMiraiScript.kt
@@ -73,7 +73,6 @@ class LuaMiraiScript(
             STDERR = stderr?.let(::PrintStream)
             STDIN = stdin
         }
-        initSearchPath(source)
         mainFunc = globals.load(mainInputStream, source.name, "bt", globals)
     }
 
@@ -126,19 +125,6 @@ class LuaMiraiScript(
         load(JDBCLib(LuaMiraiValueMapper))
         load(JsoupLib(LuaMiraiValueMapper))
         load(SocketLib(LuaMiraiValueMapper))
-    }
-
-    private fun initSearchPath(botScriptSource: BotScriptSource) {
-        when (botScriptSource) {
-            is BotScriptSource.Wrapper -> {
-                initSearchPath(botScriptSource.source)
-            }
-            is BotScriptSource.FileSource -> {
-                globals.get("package").apply {
-                    set("path", get("path").optjstring("?.lua") + ";${botScriptSource.file.parent}/?.lua")
-                }
-            }
-        }
     }
 
     class ResourceFinderAdapter(

--- a/lua-mirai-adapter-luakt/src/main/kotlin/com/github/only52607/luamirai/lua/LuaMiraiScriptBuilder.kt
+++ b/lua-mirai-adapter-luakt/src/main/kotlin/com/github/only52607/luamirai/lua/LuaMiraiScriptBuilder.kt
@@ -4,8 +4,13 @@ import com.github.only52607.luamirai.core.BotScriptBuilder
 import com.github.only52607.luamirai.core.script.BotScript
 import com.github.only52607.luamirai.core.script.BotScriptHeader
 import com.github.only52607.luamirai.core.script.BotScriptSource
+import com.github.only52607.luamirai.core.script.mutableBotScriptHeaderOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import java.io.BufferedInputStream
 
 /**
@@ -44,16 +49,35 @@ class LuaMiraiScriptBuilder(
 
     private suspend fun prepareHeader() {
         if (headerInitialized) return
-        prepareMainInputStream()
+        val manifestInputStream = source.resourceFinder?.findResource("manifest.json")
+        header = if (manifestInputStream != null) {
+            readHeaderFromJsonManifest(String(manifestInputStream.readBytes()))
+        } else {
+            prepareMainInputStream()
+            readHeaderFromCodeInputStream()
+        }
+        headerInitialized = true
+    }
+
+    private suspend fun readHeaderFromCodeInputStream(): BotScriptHeader {
         mainInputStream.mark(MAX_SCRIPT_HEADER)
-        withContext(Dispatchers.IO) {
+        return withContext(Dispatchers.IO) {
             try {
-                header = LuaHeaderReader.readHeader(mainInputStream)
+                LuaHeaderReader.readHeader(mainInputStream)
             } finally {
                 mainInputStream.reset()
             }
         }
-        headerInitialized = true
+    }
+
+    private fun readHeaderFromJsonManifest(jsonString: String): BotScriptHeader {
+        val json = Json
+        val manifest: JsonObject = json.parseToJsonElement(jsonString).jsonObject
+        return mutableBotScriptHeaderOf {
+            manifest["header"]?.jsonObject?.forEach { key, value ->
+                this@mutableBotScriptHeaderOf[key] = value.jsonPrimitive.content
+            }
+        }
     }
 
     override suspend fun buildInstance(): BotScript {

--- a/lua-mirai-configuration/src/main/kotlin/com/github/only52607/luamirai/configuration/ConfigurableScriptSource.kt
+++ b/lua-mirai-configuration/src/main/kotlin/com/github/only52607/luamirai/configuration/ConfigurableScriptSource.kt
@@ -2,7 +2,6 @@ package com.github.only52607.luamirai.configuration
 
 import com.github.only52607.luamirai.core.script.BotScriptSource
 import kotlinx.serialization.Serializable
-import java.io.InputStream
 
 /**
  * ClassName: ConfigurableScriptSource
@@ -13,19 +12,7 @@ import java.io.InputStream
  */
 @Serializable(ConfigurableScriptSourceSerializer::class)
 class ConfigurableScriptSource(
-    val source: BotScriptSource,
+    source: BotScriptSource,
     var alias: String? = null,
     var autoStart: Boolean = false
-) : BotScriptSource(
-    lang = source.lang,
-    name = source.name,
-    size = source.size,
-    charset = source.charset,
-) {
-    override val mainInputStream: InputStream
-        get() = source.mainInputStream
-
-    override fun toString(): String {
-        return source.toString()
-    }
-}
+) : BotScriptSource.Wrapper(source)

--- a/lua-mirai-core/build.gradle
+++ b/lua-mirai-core/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.2"
+}

--- a/lua-mirai-core/src/main/kotlin/com/github/only52607/luamirai/core/script/BotScriptSource.kt
+++ b/lua-mirai-core/src/main/kotlin/com/github/only52607/luamirai/core/script/BotScriptSource.kt
@@ -1,10 +1,16 @@
 package com.github.only52607.luamirai.core.script
 
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import java.io.ByteArrayInputStream
 import java.io.File
+import java.io.FileNotFoundException
 import java.io.InputStream
 import java.net.URL
 import java.nio.charset.Charset
+import java.util.zip.ZipFile
 
 /**
  * ClassName: BotScriptSource
@@ -19,11 +25,46 @@ abstract class BotScriptSource(
     var name: String,
     open var size: Long?,
     open val charset: Charset?,
-    val resourceFinder: BotScriptResourceFinder? = null
+
 ) {
     abstract val mainInputStream: InputStream
 
+    open val resourceFinder: BotScriptResourceFinder? = null
+
     class FileSource(
+        val file: File,
+        scriptLang: String,
+        name: String = "@${file.name}",
+        charset: Charset = Charsets.UTF_8
+    ) : BotScriptSource(scriptLang, name, file.length(), charset) {
+        private var textFileSource: TextFileSource? = null
+        private var zipFileSource: ZipSource? = null
+
+        init {
+            if (isPackage()) {
+                zipFileSource = ZipSource(file, scriptLang, name, charset)
+            } else {
+                textFileSource = TextFileSource(file, scriptLang, name, charset)
+            }
+        }
+
+        private fun isPackage(): Boolean {
+            return file.name.endsWith(".zip") || file.name.endsWith(".lmpk")
+        }
+
+        override val mainInputStream: InputStream
+            get() = zipFileSource?.mainInputStream ?: textFileSource?.mainInputStream
+            ?: throw Exception("FileSource has not been initialized")
+
+        override val resourceFinder: BotScriptResourceFinder?
+            get() = zipFileSource?.resourceFinder ?: textFileSource?.resourceFinder
+
+        override fun toString(): String {
+            return "FileSource(name=$name, file=$file, lang=$lang)"
+        }
+    }
+
+    class TextFileSource(
         val file: File,
         scriptLang: String,
         name: String = "@${file.name}",
@@ -33,7 +74,48 @@ abstract class BotScriptSource(
             get() = file.inputStream()
 
         override fun toString(): String {
-            return "FileSource(name=$name, file=$file, lang=$lang)"
+            return "TextFileSource(name=$name, file=$file, lang=$lang)"
+        }
+    }
+
+    class ZipSource(
+        val file: File,
+        scriptLang: String,
+        name: String = "@${file.name}",
+        charset: Charset = Charsets.UTF_8
+    ) : BotScriptSource(scriptLang, name, file.length(), charset) {
+
+        private val zipFile = ZipFile(file)
+
+        private val json = Json
+
+        private val manifest: JsonObject = getInputStream("manifest.json")?.let {
+            json.parseToJsonElement(String(it.readBytes())).jsonObject
+        } ?: throw FileNotFoundException("manifest.json not found in ${file.absolutePath}")
+
+        private val mainFileName: String = manifest["main"]?.jsonPrimitive?.content
+            ?: throw Exception("You must specify the main field as the script entry")
+
+        init {
+            super.name = mainFileName
+        }
+
+        private fun getInputStream(name: String) = zipFile.getEntry(name)?.let { zipFile.getInputStream(it) }
+
+        override val mainInputStream: InputStream
+            get() = getInputStream(mainFileName)
+                ?: throw FileNotFoundException("File $mainFileName not found in ${file.absolutePath}")
+
+        override val resourceFinder: BotScriptResourceFinder
+            get() = object : BotScriptResourceFinder {
+                override fun findResource(filename: String): InputStream? {
+                    val zipEntryName = filename.replace("\\", "/")
+                    return getInputStream(zipEntryName)
+                }
+            }
+
+        override fun toString(): String {
+            return "ZipSource(name=$name, file=$file, lang=$lang)"
         }
     }
 
@@ -75,6 +157,9 @@ abstract class BotScriptSource(
     ) {
         override val mainInputStream: InputStream
             get() = source.mainInputStream
+
+        override val resourceFinder: BotScriptResourceFinder?
+            get() = source.resourceFinder
 
         override fun toString(): String {
             return source.toString()

--- a/lua-mirai-core/src/main/kotlin/com/github/only52607/luamirai/core/script/BotScriptSource.kt
+++ b/lua-mirai-core/src/main/kotlin/com/github/only52607/luamirai/core/script/BotScriptSource.kt
@@ -64,6 +64,15 @@ abstract class BotScriptSource(
         name: String = "@${file.name}",
         charset: Charset = Charsets.UTF_8
     ) : BotScriptSource(scriptLang, name, file.length(), charset) {
+        override val resourceFinder: BotScriptResourceFinder = object : BotScriptResourceFinder {
+            val directory = file.parentFile
+            override fun findResource(filename: String): InputStream? {
+                val file = File(directory, filename)
+                if (!file.exists()) return null
+                return file.inputStream()
+            }
+        }
+
         override val mainInputStream: InputStream
             get() = file.inputStream()
 

--- a/lua-mirai-core/src/main/kotlin/com/github/only52607/luamirai/core/script/BotScriptSource.kt
+++ b/lua-mirai-core/src/main/kotlin/com/github/only52607/luamirai/core/script/BotScriptSource.kt
@@ -64,4 +64,20 @@ abstract class BotScriptSource(
             return "URLSource(name=$name, url=$url, lang=$lang)"
         }
     }
+
+    open class Wrapper(
+        val source: BotScriptSource
+    ) : BotScriptSource(
+        lang = source.lang,
+        name = source.name,
+        size = source.size,
+        charset = source.charset,
+    ) {
+        override val mainInputStream: InputStream
+            get() = source.mainInputStream
+
+        override fun toString(): String {
+            return source.toString()
+        }
+    }
 }

--- a/lua-mirai-mcl-plugin/src/main/kotlin/com/github/only52607/luamirai/console/LuaMiraiCommand.kt
+++ b/lua-mirai-mcl-plugin/src/main/kotlin/com/github/only52607/luamirai/console/LuaMiraiCommand.kt
@@ -109,8 +109,8 @@ class LuaMiraiCommand(
         }
         val builder = BotScriptBuilder.fromSource(ConfigurableScriptSource(source))
         builders.add(builder)
-        logger.info("添加脚本源[${builders.size - 1}] $fileName 成功，脚本信息：")
-        logger.info(builder.readHeader().simpleInfo)
+        logger.info("添加脚本源[${builders.size - 1}] $fileName 成功")
+        logger.info("脚本信息：\n" + builder.readHeader().simpleInfo)
         updateConfig()
     }
 


### PR DESCRIPTION
### 简述
LMPK是一组脚本的集合，可用Zip或目录形式表述。

### 加载规则
与普通脚本载入方式相同，当加载文件符合以下条件时，该文件会被解析为LMPK脚本包

1. 以`zip`或`lmpk`后缀结尾的zip包
2. 该文件是一个目录

其他情况下，文件会被解析为单个lua脚本文件

### LMPK格式说明
LMPK可以是一个目录或zip文件，且其必须包含一个名为`manifest.json`的清单文件，以json形式表示。以下是`manifest.json`的一个示例

```json
{
    "header": {
        "name": "lmpk测试",
        "author": "ooooonly",
        "version": "1.0",
        "description": "这是一个示例"
    },
    "main": "main.lua"
}
```

其中，`main`字段指定了入口文件，当脚本包被加载后，该入口文件首先会被执行。

`header`字段取代了普通脚本开头的头部信息，脚本头部的信息将被忽略，字段与原脚本头部字段相同。

入口文件可使用`require`等方式加载脚本包内其他模块，`lm`将从`manifest.json`所在目录进行路径搜寻。

